### PR TITLE
fix: Allow user to submit challenge with max number of attempts set.

### DIFF
--- a/server/src/challenge/checkAnswer.js
+++ b/server/src/challenge/checkAnswer.js
@@ -133,7 +133,7 @@ export default async event => {
 
     const wasCorrect = verifyAnswer(challenge.answer, answer);
 
-    if (solution && solution.attempts >= MAX_NUMBER_OF_ATTEMPTS) {
+    if (solution && solution.attempts > MAX_NUMBER_OF_ATTEMPTS) {
       return { error: 'No attempts remaining' };
     } else if (wasCorrect && solution == null) {
       // No previous entry, answer is correct


### PR DESCRIPTION
Currently the user will receive an error for the `$(MAX_NUMBER_OF_ATTEMPTS)`th submission.

With the current limit, the 60th submission would be marked as over the limit. I'd say you should be allowed to submit the submission with the max number set, and disallowing going over the limit rather than hitting the limit.